### PR TITLE
Update the quantum Docker file

### DIFF
--- a/Dockerfile-qt
+++ b/Dockerfile-qt
@@ -7,9 +7,10 @@ USER root
 ENV DEBIAN_FRONTEND noninteractive
 
 #
-# Dockefile for ECEN 5016 : Fundamentals of Quantum Eng
+# Dockefile for CSCI 3090 : Quantum Computing
+#               ECEN 4925 : Quantum Hardware
 #
-RUN pip install pytest cvxpy qutip qiskit networkx noisyopt
+RUN pip install pytest cvxpy qutip qiskit networkx noisyopt qiskit-ibm-runtime
 
 # Install qiskit-textbook for additional qiskit helpers
 RUN pip install git+https://github.com/qiskit-community/qiskit-textbook.git#subdirectory=qiskit-textbook-src


### PR DESCRIPTION
IBM has changed their interface so apparently we need to include a new module.

So the main purpose of this PR is to update the installation to include `qiskit-ibm-runtime`.

I also updated the comment which points to the classes that use this docker file to be CSCI/PHYS 3060 and ECEN 4525.